### PR TITLE
Update adversary.py

### DIFF
--- a/adversary.py
+++ b/adversary.py
@@ -102,7 +102,8 @@ class Adversary(object):
 
         return False
 
-    def get_pwnage_time(self, guard):
+    def 
+    (self, guard):
         """
         Get time needed to pwn this Guard, based on adversary type
         """
@@ -138,7 +139,7 @@ class Adversary(object):
 
         # Now let's handle the pwnage within 15 days in a linear way
         maximum = 60*60*24*15
-        time_to_pwnage = maximum * float(roll)
+        time_to_pwnage = maximum * 2* float(roll)
 
         logging.info("\t %s will get pwned in %d hours",
                      guard.nickname, time_to_pwnage/3600)
@@ -154,6 +155,7 @@ class Adversary(object):
 
         # Handle the 75% chance within 15 days
         if (roll < 0.75):
+            roll = random.random()
             maximum = 60*60*24*15
             time_to_pwnage = maximum * float(roll)
         else:  # Handle the 100% within a month (so within 15 days to 30 days)
@@ -180,8 +182,9 @@ class Adversary(object):
         # Handle the 50% chance within 2 days
         if (roll < 0.5):
             maximum = 60*60*24*2
-            time_to_pwnage = maximum * float(roll)
+            time_to_pwnage = maximum * 2* float(roll)
         elif (roll <= 0.75):
+            roll = random.random()
             maximum = 60*60*24*7
             time_to_pwnage = maximum * float(roll)
 
@@ -201,7 +204,7 @@ class Adversary(object):
             logging.info("\t %s has too many guards of its own for thugs", guard.nickname)
             return -1
 
-        time_to_pwnage = 60*60*24*2 + 60*60*24*12 * float(roll)
+        time_to_pwnage = 60*60*24*2 + 60*60*24*12 * 2* float(roll)
 
         logging.info("\t %s will get pwned in %d hours",
                      guard.nickname, time_to_pwnage/3600)
@@ -219,7 +222,7 @@ class Adversary(object):
             logging.info("\t %s has too many guards of its own for thugs", guard.nickname)
             return -1
 
-        time_to_pwnage = 60*60*24*7 + 60*60*24*14 * float(roll)
+        time_to_pwnage = 60*60*24*7 + 60*60*24*14 * 2* float(roll)
 
         logging.info("\t %s will get pwned in %d hours",
                      guard.nickname, time_to_pwnage/3600)


### PR DESCRIPTION
Random values will never reach their maximum proposed value. 
For example: 
Basic Adversary: rises linearly to 50% within 15 days 
Using at line 135 roll > 0.5 to see if the node can be exploited. If roll < 0.5 then the node should be exploitable between 15 days.
But at line 142 this means time_to_pwnage will get a value from (0,60*60*24*15*0.5] =  0 to 7.5 days

Proposed a fix to all attacker types